### PR TITLE
Tc1 restructure db

### DIFF
--- a/backend/prisma/migrations/20240716175141_combine_team_players_into_player_model/migration.sql
+++ b/backend/prisma/migrations/20240716175141_combine_team_players_into_player_model/migration.sql
@@ -1,0 +1,42 @@
+/*
+  Warnings:
+
+  - You are about to drop the `MyTeamPlayer` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `OpponentTeamPlayer` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `myTeamUserId` to the `Player` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `opponentUserId` to the `Player` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "MyTeamPlayer" DROP CONSTRAINT "MyTeamPlayer_playerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "MyTeamPlayer" DROP CONSTRAINT "MyTeamPlayer_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "OpponentTeamPlayer" DROP CONSTRAINT "OpponentTeamPlayer_playerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "OpponentTeamPlayer" DROP CONSTRAINT "OpponentTeamPlayer_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "Player" ADD COLUMN     "consistencyScore" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "defenseDisciplineScore" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "insideOffenseScore" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "myTeamUserId" INTEGER NOT NULL,
+ADD COLUMN     "offenseDisciplineScore" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "opponentUserId" INTEGER NOT NULL,
+ADD COLUMN     "outsideOffenseScore" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "reboundingScore" INTEGER NOT NULL DEFAULT 0;
+
+-- DropTable
+DROP TABLE "MyTeamPlayer";
+
+-- DropTable
+DROP TABLE "OpponentTeamPlayer";
+
+-- AddForeignKey
+ALTER TABLE "Player" ADD CONSTRAINT "Player_myTeamUserId_fkey" FOREIGN KEY ("myTeamUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Player" ADD CONSTRAINT "Player_opponentUserId_fkey" FOREIGN KEY ("opponentUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20240716182635_fix_required_elements/migration.sql
+++ b/backend/prisma/migrations/20240716182635_fix_required_elements/migration.sql
@@ -1,0 +1,52 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `myTeamUserId` on the `Player` table. All the data in the column will be lost.
+  - You are about to drop the column `opponentUserId` on the `Player` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Player" DROP CONSTRAINT "Player_myTeamUserId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Player" DROP CONSTRAINT "Player_opponentUserId_fkey";
+
+-- AlterTable
+ALTER TABLE "Player" DROP COLUMN "myTeamUserId",
+DROP COLUMN "opponentUserId";
+
+-- CreateTable
+CREATE TABLE "_myTeamPlayers" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_opponents" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_myTeamPlayers_AB_unique" ON "_myTeamPlayers"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_myTeamPlayers_B_index" ON "_myTeamPlayers"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_opponents_AB_unique" ON "_opponents"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_opponents_B_index" ON "_opponents"("B");
+
+-- AddForeignKey
+ALTER TABLE "_myTeamPlayers" ADD CONSTRAINT "_myTeamPlayers_A_fkey" FOREIGN KEY ("A") REFERENCES "Player"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_myTeamPlayers" ADD CONSTRAINT "_myTeamPlayers_B_fkey" FOREIGN KEY ("B") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_opponents" ADD CONSTRAINT "_opponents_A_fkey" FOREIGN KEY ("A") REFERENCES "Player"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_opponents" ADD CONSTRAINT "_opponents_B_fkey" FOREIGN KEY ("B") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -51,10 +51,8 @@ model Player {
   defenseDisciplineScore Int      @default(0)
   consistencyScore       Int      @default(0)
   reboundingScore        Int      @default(0)
-  myTeams                User     @relation("myTeamPlayers", fields: [myTeamUserId], references: [id])
-  myTeamUserId           Int
-  opponentTeams          User     @relation("opponents", fields: [opponentUserId], references: [id])
-  opponentUserId         Int
+  myTeams                User[]   @relation("myTeamPlayers")
+  opponentTeams          User[]   @relation("opponents")
 }
 
 model User {

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -15,74 +15,52 @@ datasource db {
 
 // All Player stats are totals over the entire season
 model Player {
-  id                Int                  @id @default(autoincrement())
-  player_name       String
-  age               Int
-  games             Int
-  games_started     Int
-  minutes_played    Int
-  field_goals       Int
-  field_attempts    Int
-  field_percent     Float
-  three_fg          Int
-  three_attempts    Int
-  three_percent     Float
-  two_fg            Int
-  two_attempts      Int
-  two_percent       Float
-  effect_fg_percent String
-  ft                Int
-  fta               Int
-  ft_percent        Float
-  ORB               Int // Offensive Rebound
-  DRB               Int // Defensive Rebound
-  TRB               Int // Total Rebounds
-  AST               Int // Assists
-  STL               Int // Steals
-  BLK               Int // Blocks
-  TOV               Int // Turnovers
-  PF                Int // Personal Fouls
-  PTS               Int // Points
-  team              String
-  createdAt         DateTime             @default(now())
-  teamPlayer        MyTeamPlayer[]
-  opponent          OpponentTeamPlayer[]
-}
-
-model MyTeamPlayer {
-  id                     Int    @id @default(autoincrement())
-  player                 Player @relation(fields: [playerId], references: [id], onDelete: Cascade)
-  playerId               Int
-  playerName             String @default("")
-  user                   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId                 Int
-  outsideOffenseScore    Int    @default(0)
-  insideOffenseScore     Int    @default(0)
-  offenseDisciplineScore Int    @default(0)
-  defenseDisciplineScore Int    @default(0)
-  consistencyScore       Int    @default(0)
-  reboundingScore        Int    @default(0)
+  id                     Int      @id @default(autoincrement())
+  player_name            String
+  age                    Int
+  games                  Int
+  games_started          Int
+  minutes_played         Int
+  field_goals            Int
+  field_attempts         Int
+  field_percent          Float
+  three_fg               Int
+  three_attempts         Int
+  three_percent          Float
+  two_fg                 Int
+  two_attempts           Int
+  two_percent            Float
+  effect_fg_percent      String
+  ft                     Int
+  fta                    Int
+  ft_percent             Float
+  ORB                    Int // Offensive Rebound
+  DRB                    Int // Defensive Rebound
+  TRB                    Int // Total Rebounds
+  AST                    Int // Assists
+  STL                    Int // Steals
+  BLK                    Int // Blocks
+  TOV                    Int // Turnovers
+  PF                     Int // Personal Fouls
+  PTS                    Int // Points
+  team                   String
+  createdAt              DateTime @default(now())
+  outsideOffenseScore    Int      @default(0)
+  insideOffenseScore     Int      @default(0)
+  offenseDisciplineScore Int      @default(0)
+  defenseDisciplineScore Int      @default(0)
+  consistencyScore       Int      @default(0)
+  reboundingScore        Int      @default(0)
+  myTeams                User     @relation("myTeamPlayers", fields: [myTeamUserId], references: [id])
+  myTeamUserId           Int
+  opponentTeams          User     @relation("opponents", fields: [opponentUserId], references: [id])
+  opponentUserId         Int
 }
 
 model User {
-  id            Int                  @id @default(autoincrement())
-  username      String               @unique
+  id            Int      @id @default(autoincrement())
+  username      String   @unique
   password      String
-  myTeamPlayers MyTeamPlayer[]
-  opponents     OpponentTeamPlayer[]
-}
-
-model OpponentTeamPlayer {
-  id                     Int    @id @default(autoincrement())
-  player                 Player @relation(fields: [playerId], references: [id], onDelete: Cascade)
-  playerId               Int
-  user                   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId                 Int
-  playerName             String @default("")
-  outsideOffenseScore    Int    @default(0)
-  insideOffenseScore     Int    @default(0)
-  offenseDisciplineScore Int    @default(0)
-  defenseDisciplineScore Int    @default(0)
-  consistencyScore       Int    @default(0)
-  reboundingScore        Int    @default(0)
+  myTeamPlayers Player[] @relation("myTeamPlayers")
+  opponents     Player[] @relation("opponents")
 }

--- a/backend/routes/cronJob.js
+++ b/backend/routes/cronJob.js
@@ -83,7 +83,6 @@ async function createPlayer(player) {
   player.consistencyScore = performanceScores.consistencyScore;
   player.reboundingScore = performanceScores.reboundingScore;
 
-  console.log(player);
   const newPlayer = await prisma.player.create({
     data: {
       AST: player.BLK,

--- a/backend/routes/cronJob.js
+++ b/backend/routes/cronJob.js
@@ -1,3 +1,5 @@
+//This file holds the functions run during the daily cron job to update the database
+
 import { PrismaClient } from "@prisma/client";
 import {
   STAT_MEANS,

--- a/backend/routes/run.js
+++ b/backend/routes/run.js
@@ -5,6 +5,7 @@ import {
   POP_SIZE,
   incrementPopSize,
 } from "./statDictionaries.js";
+import { calcPerformanceScores } from "./scoreCalculations.js";
 const prisma = new PrismaClient();
 
 async function updatePlayer(player) {
@@ -72,6 +73,15 @@ async function createPlayer(player) {
     ? "0"
     : player.effect_fg_percent;
 
+  const performanceScores = await calcPerformanceScores(player);
+  player.outsideOffenseScore = performanceScores.outsideOffenseScore;
+  player.insideOffenseScore = performanceScores.insideOffenseScore;
+  player.offenseDisciplineScore = performanceScores.offenseDisciplineScore;
+  player.defenseDisciplineScore = performanceScores.defenseDisciplineScore;
+  player.consistencyScore = performanceScores.consistencyScore;
+  player.reboundingScore = performanceScores.reboundingScore;
+
+  console.log(player);
   const newPlayer = await prisma.player.create({
     data: {
       AST: player.BLK,
@@ -103,6 +113,12 @@ async function createPlayer(player) {
       two_attempts: player.two_attempts,
       two_fg: player.two_fg,
       two_percent: two_percent,
+      outsideOffenseScore: player.outsideOffenseScore,
+      insideOffenseScore: player.insideOffenseScore,
+      offenseDisciplineScore: player.offenseDisciplineScore,
+      defenseDisciplineScore: player.defenseDisciplineScore,
+      consistencyScore: player.consistencyScore,
+      reboundingScore: player.reboundingScore,
     },
   });
   return newPlayer;
@@ -184,11 +200,9 @@ async function run() {
     queryUrl = data.next;
 
     for (let i = 0; i < players.length; ++i) {
-      updatePlayer(players[i]);
+      updatePlayer(players[0]);
     }
   } while (queryUrl !== null);
-
-  return {};
 }
 
 export { run, updatePopulationStats };

--- a/backend/routes/scoreCalculations.js
+++ b/backend/routes/scoreCalculations.js
@@ -84,13 +84,7 @@ function calcReboundingScore(games, ORB, DRB) {
   return INIT_SCORE - 10 + 10 * (ORB / games) + 6 * (DRB / games);
 }
 
-async function calcPerformanceScores(playerId) {
-  let player = await prisma.player.findUnique({
-    where: {
-      id: playerId,
-    },
-  });
-
+async function calcPerformanceScores(player) {
   const outsideOffenseScore = calcOutSideOffenseScore(
     player.field_attempts,
     player.three_attempts,

--- a/backend/server.js
+++ b/backend/server.js
@@ -5,8 +5,8 @@ import userRoutes from "./routes/users.js";
 import cron from "node-cron";
 import { PrismaClient } from "@prisma/client";
 import { calcPerformanceScores } from "./routes/scoreCalculations.js";
-import { run } from "./routes/run.js";
-import { updatePopulationStats } from "./routes/run.js";
+import { run } from "./routes/cronJob.js";
+import { updatePopulationStats } from "./routes/cronJob.js";
 const prisma = new PrismaClient();
 
 import express from "express";


### PR DESCRIPTION
## Description

Restructuring the database to reflect design choice changes. Removed the MyTeam and Opponent tables. All performance scores are held with each individual's playing stats, meaning that performance scores are now independent of teammates.
Will be updating the formulas for calculating performance score in the next pr.

## Milestones
The cron job that runs every night (in cronJob.js) will also handle calculating the performance scores of every player in the league.

## Resources
Database Plan
<img width="1089" alt="Screenshot 2024-07-16 at 10 57 51 AM" src="https://github.com/user-attachments/assets/e85afe51-3636-4290-9642-0d06a59ddd66">
Note: the myTeamOOS, myTeam IOS, are placeholders for caching the team's aggregate performance scores. These would be allow us to avoid unneccesary computation when the user chooses to see the playing style multiple times without changing their teams. They are not included in the actual database right now, because I want to focus on the functionality first.

## Test Plan
No demo, since the cron job is currently being debugged, but I will include that in the next pr.

