### PR TITLE
Merge to deploy

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -46,6 +46,8 @@ app.use(userRoutes);
 //GETS
 app.get("/players", async (req, res) => {
   const { sortType, sortDirection, playerName } = req.query;
+  const startPlayerIndex = parseInt(req.query.startPlayerIndex);
+  const rowsPerPage = parseInt(req.query.rowsPerPage);
 
   if (sortType != "no_sort" && sortDirection != "no_direction") {
     try {
@@ -60,6 +62,8 @@ app.get("/players", async (req, res) => {
               }
             : {}),
         },
+        skip: startPlayerIndex,
+        take: rowsPerPage,
         orderBy: [
           {
             [sortType]: sortDirection,
@@ -83,6 +87,8 @@ app.get("/players", async (req, res) => {
               }
             : {}),
         },
+        skip: startPlayerIndex,
+        take: rowsPerPage,
       });
       res.json(players);
     } catch (error) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -158,6 +158,15 @@ app.get("/scoutOpponent", async (req, res) => {
   }
 });
 
+app.get("/playersCount", async (req, res) => {
+  try {
+    const playerCount = await prisma.player.count();
+    return res.json(playerCount);
+  } catch {
+    console.error(error);
+  }
+});
+
 //UPDATES
 app.patch("/player", async (req, res) => {
   const playerType = req.body.playerType;

--- a/frontend/src/players_view/PlayersView.jsx
+++ b/frontend/src/players_view/PlayersView.jsx
@@ -12,7 +12,6 @@ function PlayersView() {
   const PORT = import.meta.env.VITE_BACKEND_PORT;
   const [displayServerError, setDisplayServerError] = useState(false);
 
-  const [playersDisplayed, setPlayersDisplayed] = useState([]);
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
 
@@ -41,7 +40,10 @@ function PlayersView() {
       let queryUrl = new URL(`${PORT}/players`);
       queryUrl.searchParams.append("sortType", sortType);
       queryUrl.searchParams.append("sortDirection", sortDirection);
+      queryUrl.searchParams.append("startPlayerIndex", page * rowsPerPage);
+      queryUrl.searchParams.append("rowsPerPage", rowsPerPage);
       queryUrl.searchParams.append("playerName", searchQuery);
+
       const response = await fetch(queryUrl);
       const players = await response.json();
       return players;
@@ -52,16 +54,8 @@ function PlayersView() {
   }
 
   useEffect(() => {
-    const start = page * rowsPerPage;
-    const end = start + rowsPerPage;
-    setPlayersDisplayed(
-      playersList.data ? playersList.data.slice(start, end) : []
-    );
-  }, [page, rowsPerPage, playersList.data]);
-
-  useEffect(() => {
     playersList.refetch();
-  }, [sortType, sortDirection, searchQuery]);
+  }, [sortType, sortDirection, searchQuery, page, rowsPerPage]);
 
   return (
     <div className="view playersView">
@@ -78,14 +72,14 @@ function PlayersView() {
             <SearchBar setSearchQuery={setSearchQuery} />
           </div>
           <StatsTable
-            playersList={playersDisplayed}
+            playersList={playersList.data}
             setSortType={setSortType}
             setSortDirection={setSortDirection}
             sortType={sortType}
           />
           <TablePagination
             component="div"
-            count={playersList.data.length}
+            count={10}
             page={page}
             onPageChange={handleChangePage}
             rowsPerPage={rowsPerPage}

--- a/frontend/src/players_view/PlayersView.jsx
+++ b/frontend/src/players_view/PlayersView.jsx
@@ -26,6 +26,16 @@ function PlayersView() {
   const [sortDirection, setSortDirection] = useState("no_direction");
   const [searchQuery, setSearchQuery] = useState("");
 
+  const playersCount = useQuery({
+    queryKey: ["playersCount"],
+    queryFn: async () => {
+      let queryUrl = new URL(`${PORT}/playersCount`);
+      const response = await fetch(queryUrl);
+      const playersCount = await response.json();
+      return playersCount;
+    },
+  });
+
   const handleChangePage = (event, newPage) => {
     setPage(newPage);
   };
@@ -79,7 +89,7 @@ function PlayersView() {
           />
           <TablePagination
             component="div"
-            count={10}
+            count={playersCount.data}
             page={page}
             onPageChange={handleChangePage}
             rowsPerPage={rowsPerPage}

--- a/frontend/src/single_player/ShotChart.jsx
+++ b/frontend/src/single_player/ShotChart.jsx
@@ -1,11 +1,11 @@
 import * as d3 from "d3";
 import { useMemo } from "react";
-import "./ShotChart.css";
+import "./SinglePlayerView.css";
 
 function ShotChart({ shotChartData, height, width }) {
   const MARGIN = { top: 10, right: 10, bottom: 30, left: 30 };
-  const boundsWidth = 1000 - MARGIN.right - MARGIN.left;
-  const boundsHeight = 800 - MARGIN.top - MARGIN.bottom;
+  const boundsWidth = height - MARGIN.right - MARGIN.left;
+  const boundsHeight = width - MARGIN.top - MARGIN.bottom;
 
   const rows = useMemo(
     () => [...new Set(shotChartData.map((dataPoint) => dataPoint.top))],
@@ -16,17 +16,9 @@ function ShotChart({ shotChartData, height, width }) {
     [shotChartData]
   );
 
-  const xScale = d3
-    .scaleBand()
-    .range([0, boundsWidth])
-    .domain(columns)
-    .padding(0.01);
+  const xScale = d3.scaleBand().range([0, 600]).domain(columns).padding(0.01);
 
-  const yScale = d3
-    .scaleBand()
-    .range([boundsHeight, 0])
-    .domain(rows)
-    .padding(0.01);
+  const yScale = d3.scaleBand().range([500, 0]).domain(rows).padding(0.01);
 
   const [min, max] = d3.extent(
     shotChartData.map((dataPoint) => dataPoint.value)
@@ -65,13 +57,7 @@ function ShotChart({ shotChartData, height, width }) {
         alt="court image overlay"
       />
       <svg className="heatMap" width={width} height={height}>
-        <g
-          width={boundsWidth}
-          height={boundsHeight}
-          transform={`translate(${[MARGIN.left, MARGIN.top].join(",")})`}
-        >
-          {chartRegions}
-        </g>
+        <g className="heatRegions">{chartRegions}</g>
       </svg>
     </div>
   );

--- a/frontend/src/single_player/SinglePlayerView.css
+++ b/frontend/src/single_player/SinglePlayerView.css
@@ -1,26 +1,40 @@
 /* Taken from https://stackoverflow.com/questions/43806515/position-svg-elements-over-an-image */
 
+.models {
+  display: flex;
+  justify-content: space-around;
+}
+
 .img-overlay-wrap {
   position: relative;
   display: inline-block;
   transition: transform 150ms ease-in-out;
-  width: 1000px;
-  height: 800px;
-  overflow: hidden;
+  width: 600px;
+  height: 500px;
+}
+
+.shotChart {
+  min-width: 600px;
+  height: 500px;
+  margin: 20px;
 }
 
 .img-overlay-wrap img {
   position: absolute;
+  top: 0;
+  left: 0;
   display: block;
-  max-width: 100%;
-  height: auto;
-  transform: rotate(180deg) translate(10px, 170px);
-  width: 970px;
-  margin-left: 20px;
+  width: 600px;
+  height: 500px;
+  transform: rotate(180deg);
 }
 
 .img-overlay-wrap svg {
   position: absolute;
   top: 0;
   left: 0;
+}
+
+.heatRegions {
+  width: 100%;
 }

--- a/frontend/src/single_player/SinglePlayerView.jsx
+++ b/frontend/src/single_player/SinglePlayerView.jsx
@@ -11,6 +11,7 @@ import ShotChart from "./ShotChart.jsx";
 import { PlayerStats } from "./PlayerStats.js";
 import ErrorAlert from "../suspense/ErrorAlert.jsx";
 import FeedbackAlert from "../suspense/FeedbackAlert.jsx";
+import "./SinglePlayerView.css";
 
 function SinglePlayerView() {
   const PORT = import.meta.env.VITE_BACKEND_PORT;
@@ -122,10 +123,10 @@ function SinglePlayerView() {
 
     shotCoordinates.forEach((coord) => {
       const row = Math.floor(
-        coord.top / ((PIXEL_TO_REGION_SCALING_FACTOR - 100) / SHOT_CHART_COLS)
+        coord.top / (PIXEL_TO_REGION_SCALING_FACTOR / SHOT_CHART_ROWS)
       );
       const col = Math.floor(
-        coord.left / (PIXEL_TO_REGION_SCALING_FACTOR / SHOT_CHART_ROWS)
+        coord.left / (PIXEL_TO_REGION_SCALING_FACTOR / SHOT_CHART_COLS)
       );
       shotMatrix[row][col] += 1;
     });
@@ -187,27 +188,29 @@ function SinglePlayerView() {
             {" "}
             Add to Opponents
           </Button>
-          <LineGraph careerData={bySeasonStats.data} />
         </div>
       )}
 
-      {shotChartData.data == null && !shotChartData.isPending && (
-        <h3>
-          {" "}
-          Shot chart not available for this player. Check Stephen Curry for an
-          example
-        </h3>
-      )}
+      <div className="models">
+        {bySeasonStats.data && <LineGraph careerData={bySeasonStats.data} />}
+        {shotChartData.data == null && !shotChartData.isPending && (
+          <h3>
+            {" "}
+            Shot chart not available for this player. Check Stephen Curry for an
+            example
+          </h3>
+        )}
 
-      {shotChartData.isPending && <h3> Loading Shot Chart ...</h3>}
+        {shotChartData.isPending && <h3> Loading Shot Chart ...</h3>}
 
-      {shotChartData.data != null && (
-        <ShotChart
-          shotChartData={shotChartData.data}
-          height={800}
-          width={1000}
-        />
-      )}
+        {shotChartData.data != null && (
+          <ShotChart
+            shotChartData={shotChartData.data}
+            height={500}
+            width={600}
+          />
+        )}
+      </div>
 
       {bySeasonStats.data && <StatsTable playersList={bySeasonStats.data} />}
     </div>


### PR DESCRIPTION
## Description
Improving the shot chart visuals and adding pagination to backend /players call

## Milestones
Scaled the shot chart down to a reasonable size
Added logic to make empty regions on the shot chart less visible with opacity
Pass only the needed data to the frontend instead of all 600 players every time the user sorts or reloads the page.

## Test Plan
<img width="1131" alt="Screenshot 2024-07-31 at 4 57 35 PM" src="https://github.com/user-attachments/assets/f5fd5688-01cf-4bbd-83e1-2970470111ce">
Backend can skip to any given index and take exactly the right number that the user needs using prisma "skip" and "take"


